### PR TITLE
feat: support children via GitHub Taskslist

### DIFF
--- a/User Guide.md
+++ b/User Guide.md
@@ -40,6 +40,7 @@ The fundamental unit of a roadmap is a project milestone. In the context of road
 - Roadmaps are represented by a single root node, or GitHub issue, which contains links to milestones contained within that roadmap.
 - The roadmap root node and child milestones can be in any public repository as long as the issues satisfy the requirements outlined in this document.
   - This means that you can link to existing GitHub issues as child milestones.
+- Errors will be logged and displayed for the user in starmap.site
 
 ### Milestone Encodings
 
@@ -93,10 +94,31 @@ can expect to get from this milestone.
 #### Children
 
 - A milestone may have child milestones.
-- Child milestones are simply full URL links to other GitHub milestone issues.
-- Child milestones can exist in any public Github repository.
+- Child milestones are simply GitHub issue identifiers (#<issue_number>, <org>/<repo>#<issue_number>, or full URLs) to other GitHub milestone issues.
+- Child milestones can exist in any public GitHub repository.
 - It is expected that child milestone issues are themselves properly encoded milestones; otherwise they will be ignored by Starmap.
 - Within a parent issue, child milestones are encoded as follows (raw Markdown):
+
+##### Tasklist syntax
+
+Tasklists allow for "taskifying" of strings, and we have no way to link a random string to a GitHub issue. You must convert any [tasks to issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-tasklists#converting-draft-issues-to-issues-in-a-tasklist) for them to show up as a child milestone.
+
+We will do our best to support the expected syntax of GitHub's tasklist functionality.
+
+See https://docs.github.com/en/issues/tracking-your-work-with-issues/about-tasklists#creating-tasklists and https://github.com/pln-planning-tools/Starmap/issues/245 for more details.
+
+```
+```[tasklist]
+### Tasks
+- [ ] https://github.com/pln-roadmap/Roadmap-Vizualizer/issues/10
+- [ ] https://github.com/pln-roadmap/Roadmap-Vizualizer/issues/9
+- [ ] https://github.com/pln-roadmap/Roadmap-Vizualizer/issues/8
+\```
+```
+
+##### "Children:" syntax
+
+This syntax is deprecated. Please see https://github.com/pln-planning-tools/Starmap/issues/245 for more details.
 
 ```
 Children:
@@ -104,7 +126,6 @@ Children:
 - https://github.com/pln-roadmap/Roadmap-Vizualizer/issues/9
 - https://github.com/pln-roadmap/Roadmap-Vizualizer/issues/8
 ```
-- Errors will be logged and displayed for the user in starmap.site
 
 ### Progress Indicators
 
@@ -127,6 +148,39 @@ Children:
 ### Templates
 
 #### Root Node Issue
+
+##### Using GitHub Tasklists
+
+```
+Title: [Team/Project Name] [Duration] Roadmap
+
+Description (optional):
+The goal of this roadmap is to outline the key milestones and deliverables for our team/project over the next [Duration].
+
+```[tasklist]
+### Any descriptor or other text
+- [ ] #123 <!-- will be recognized by starmap -->
+- [ ] org/repo#123 <!-- will be recognized by starmap -->
+- [ ] some non-link description <!-- will NOT be recognized by starmap -->
+- [ ] https://github.com/org/repo/issue/987 <!-- will be recognized by starmap -->
+
+### Any text
+- [ ] #456 <!-- will be recognized by starmap -->
+- [ ] org/repo#567 <!-- will be recognized by starmap -->
+- [ ] https://github.com/other-org/other-repo/issue/987 <!-- will be recognized by starmap -->
+
+\```
+
+Note: This roadmap is subject to change as priorities and circumstances evolve.
+
+Starmap Link: [Starmap Link]
+
+```
+
+##### Using "Children:"
+
+**NOTE:** The children: section is deprecated. Please see https://github.com/pln-planning-tools/Starmap/issues/245 for more details
+
 ```
 Title: [Team/Project Name] [Duration] Roadmap
 

--- a/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
+++ b/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
@@ -5,7 +5,7 @@ import { resolveChildren } from './resolveChildren';
 import { resolveChildrenWithDepth } from './resolveChildrenWithDepth';
 
 export async function getGithubIssueDataWithGroupAndChildren (issueData: GithubIssueDataWithGroup, errorManager: ErrorManager, usePendingChildren = false): Promise<GithubIssueDataWithGroupAndChildren> {
-  const childrenParsed: ParserGetChildrenResponse[] = getChildren(issueData.body_html);
+  const childrenParsed: ParserGetChildrenResponse[] = getChildren(issueData);
   let pendingChildren: PendingChildren[] | undefined = undefined;
   let children: GithubIssueDataWithGroupAndChildren[] = [];
 

--- a/lib/backend/issue.ts
+++ b/lib/backend/issue.ts
@@ -27,6 +27,7 @@ export async function getIssue ({ owner, repo, issue_number }): Promise<GithubIs
       state: data.state as IssueStates,
       node_id: data.node_id,
       body_html: data.body_html || '',
+      body: data.body || '',
       labels: data.labels
         .map((label) => (typeof label !== 'string' ? label.name : label)) as string[],
     };

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -71,7 +71,7 @@ function getChildrenFromTaskList(issue: Pick<GithubIssueData, 'body' | 'html_url
  * This function must support recognizing the current issue's organization and repo, because some children may simply be "#43" instead of a github short-id such as "org/repo#43"
  * @param {string} issue
  */
-export function getChildrenNew(issue: Pick<GithubIssueData, 'body' | 'html_url'>): ParserGetChildrenResponse[] {
+function getChildrenNew(issue: Pick<GithubIssueData, 'body' | 'html_url'>): ParserGetChildrenResponse[] {
 
   try {
     return getChildrenFromTaskList(issue);

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -34,7 +34,7 @@ function getSectionLines(text: string, sectionHeader: string) {
   if (sectionIndex === -1) {
     return [];
   }
-  const lines = text.substring(sectionIndex).split(/\r\n|\r|\n/).slice(1);
+  const lines = text.substring(sectionIndex).split(/[\r\n]+/).slice(1);
   return lines;
 }
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -4,6 +4,7 @@ import type { RoadmapMode, IssueStates, DateGranularityState } from './enums'
 
 export interface GithubIssueData {
   body_html: string;
+  body: string;
   html_url: string;
   labels: string[];
   node_id: string;

--- a/pages/api/roadmap.ts
+++ b/pages/api/roadmap.ts
@@ -33,7 +33,7 @@ export default async function handler(
   try {
     const rootIssue = await getIssue({ owner, repo, issue_number });
 
-    const childrenFromBodyHtml = (!!rootIssue && rootIssue.body_html && getChildren(rootIssue.body_html)) || null;
+    const childrenFromBodyHtml = (!!rootIssue && rootIssue.body_html && getChildren(rootIssue)) || null;
     let children: Awaited<ReturnType<typeof resolveChildrenWithDepth>> = [];
     try {
       if (childrenFromBodyHtml != null) {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,0 +1,87 @@
+import { getChildren } from '../../lib/parser';
+
+/**
+ * Test data obtained from calling getIssue() on github.com/protocol/engres/issues/5 on 2023-02-10 @ 5pm PST
+ */
+const example_body_html = '<p dir=\"auto\">children:</p>\n<ul dir=\"auto\">\n<li><a aria-label=\"Issue #5\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468803547\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/5\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/5/hovercard\" href=\"https://github.com/protocol/bedrock/issues/5\">protocol/bedrock#5</a></li>\n<li><a aria-label=\"Issue #11\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468828351\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/11\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/11/hovercard\" href=\"https://github.com/protocol/bedrock/issues/11\">protocol/bedrock#11</a></li>\n<li><a aria-label=\"Issue #1144\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462056698\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1144\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1144/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1144\">filecoin-project/ref-fvm#1144</a></li>\n<li><a aria-label=\"Issue #1143\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462053266\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1143\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1143/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1143\">filecoin-project/ref-fvm#1143</a></li>\n<li><a aria-label=\"Issue #34\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470149244\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/34\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/34/hovercard\" href=\"https://github.com/protocol/netops/issues/34\">protocol/netops#34</a></li>\n<li><a aria-label=\"Issue #47\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470248081\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/47\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/47/hovercard\" href=\"https://github.com/protocol/netops/issues/47\">protocol/netops#47</a></li>\n<li><a aria-label=\"Issue #8\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464684250\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/8\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/8/hovercard\" href=\"https://github.com/drand/roadmap/issues/8\">drand/roadmap#8</a></li>\n<li><a aria-label=\"Issue #12\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464687876\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/12\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/12/hovercard\" href=\"https://github.com/drand/roadmap/issues/12\">drand/roadmap#12</a></li>\n<li><a aria-label=\"Issue #180\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394534093\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/180\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/180/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/180\">protocol/ConsensusLab#180</a></li>\n<li><a aria-label=\"Issue #185\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394589312\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/185\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/185/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/185\">protocol/ConsensusLab#185</a></li>\n<li><a aria-label=\"Issue #186\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394590754\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/186\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/186/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/186\">protocol/ConsensusLab#186</a></li>\n<li><a aria-label=\"Issue #3\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461226183\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/3\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/3/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/3\">filecoin-station/roadmap#3</a></li>\n<li><a aria-label=\"Issue #10\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1575972127\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/10\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/10/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/10\">filecoin-station/roadmap#10</a></li>\n<li><a aria-label=\"Issue #1\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467798001\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/1\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/1/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/1\">filecoin-saturn/roadmap#1</a></li>\n<li><a aria-label=\"Issue #4\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461231696\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/4\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/4/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/4\">filecoin-station/roadmap#4</a></li>\n<li><a aria-label=\"Issue #2\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467801960\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/2\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/2/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/2\">filecoin-saturn/roadmap#2</a></li>\n<li><a aria-label=\"Issue #19\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464616958\" data-permission-text=\"Title is private\" data-url=\"https://github.com/cryptonetlab/roadmap/issues/19\" data-hovercard-type=\"issue\" data-hovercard-url=\"/cryptonetlab/roadmap/issues/19/hovercard\" href=\"https://github.com/cryptonetlab/roadmap/issues/19\">cryptonetlab/roadmap#19</a></li>\n</ul>\n<p dir=\"auto\">eta: 2023Q2</p>\n<p dir=\"auto\">View in <a href=\"https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple\" rel=\"nofollow\">https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple</a></p>'
+const example_body_text = 'children:\n\nprotocol/bedrock#5\nprotocol/bedrock#11\nfilecoin-project/ref-fvm#1144\nfilecoin-project/ref-fvm#1143\nprotocol/netops#34\nprotocol/netops#47\ndrand/roadmap#8\ndrand/roadmap#12\nprotocol/ConsensusLab#180\nprotocol/ConsensusLab#185\nprotocol/ConsensusLab#186\nfilecoin-station/roadmap#3\nfilecoin-station/roadmap#10\nfilecoin-saturn/roadmap#1\nfilecoin-station/roadmap#4\nfilecoin-saturn/roadmap#2\ncryptonetlab/roadmap#19\n\neta: 2023Q2\nView in https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple'
+
+describe('parser', function() {
+  describe('getChildren', function() {
+    it('Can parse children from body_html', function() {
+      const children = getChildren(example_body_html);
+      expect(Array.isArray(children)).toBe(true);
+      expect(children).toHaveLength(17);
+      expect(children).toStrictEqual([
+        {
+          group: 'children:',
+          html_url: 'https://github.com/protocol/bedrock/issues/5'
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/bedrock/issues/11",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1144",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1143",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/netops/issues/34",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/netops/issues/47",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/drand/roadmap/issues/8",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/drand/roadmap/issues/12",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/ConsensusLab/issues/180",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/ConsensusLab/issues/185",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/protocol/ConsensusLab/issues/186",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-station/roadmap/issues/3",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-station/roadmap/issues/10",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-saturn/roadmap/issues/1",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-station/roadmap/issues/4",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/filecoin-saturn/roadmap/issues/2",
+        },
+        {
+          "group": "children:",
+          "html_url": "https://github.com/cryptonetlab/roadmap/issues/19",
+        },
+      ])
+    })
+  })
+})

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,4 +1,4 @@
-import { getChildren } from '../../lib/parser';
+import { getChildren, getChildrenNew } from '../../lib/parser';
 
 /**
  * Test data obtained from calling getIssue() on github.com/protocol/engres/issues/5 on 2023-02-10 @ 5pm PST
@@ -6,82 +6,90 @@ import { getChildren } from '../../lib/parser';
 const example_body_html = '<p dir=\"auto\">children:</p>\n<ul dir=\"auto\">\n<li><a aria-label=\"Issue #5\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468803547\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/5\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/5/hovercard\" href=\"https://github.com/protocol/bedrock/issues/5\">protocol/bedrock#5</a></li>\n<li><a aria-label=\"Issue #11\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468828351\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/11\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/11/hovercard\" href=\"https://github.com/protocol/bedrock/issues/11\">protocol/bedrock#11</a></li>\n<li><a aria-label=\"Issue #1144\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462056698\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1144\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1144/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1144\">filecoin-project/ref-fvm#1144</a></li>\n<li><a aria-label=\"Issue #1143\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462053266\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1143\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1143/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1143\">filecoin-project/ref-fvm#1143</a></li>\n<li><a aria-label=\"Issue #34\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470149244\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/34\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/34/hovercard\" href=\"https://github.com/protocol/netops/issues/34\">protocol/netops#34</a></li>\n<li><a aria-label=\"Issue #47\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470248081\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/47\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/47/hovercard\" href=\"https://github.com/protocol/netops/issues/47\">protocol/netops#47</a></li>\n<li><a aria-label=\"Issue #8\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464684250\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/8\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/8/hovercard\" href=\"https://github.com/drand/roadmap/issues/8\">drand/roadmap#8</a></li>\n<li><a aria-label=\"Issue #12\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464687876\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/12\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/12/hovercard\" href=\"https://github.com/drand/roadmap/issues/12\">drand/roadmap#12</a></li>\n<li><a aria-label=\"Issue #180\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394534093\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/180\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/180/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/180\">protocol/ConsensusLab#180</a></li>\n<li><a aria-label=\"Issue #185\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394589312\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/185\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/185/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/185\">protocol/ConsensusLab#185</a></li>\n<li><a aria-label=\"Issue #186\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394590754\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/186\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/186/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/186\">protocol/ConsensusLab#186</a></li>\n<li><a aria-label=\"Issue #3\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461226183\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/3\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/3/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/3\">filecoin-station/roadmap#3</a></li>\n<li><a aria-label=\"Issue #10\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1575972127\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/10\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/10/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/10\">filecoin-station/roadmap#10</a></li>\n<li><a aria-label=\"Issue #1\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467798001\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/1\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/1/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/1\">filecoin-saturn/roadmap#1</a></li>\n<li><a aria-label=\"Issue #4\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461231696\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/4\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/4/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/4\">filecoin-station/roadmap#4</a></li>\n<li><a aria-label=\"Issue #2\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467801960\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/2\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/2/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/2\">filecoin-saturn/roadmap#2</a></li>\n<li><a aria-label=\"Issue #19\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464616958\" data-permission-text=\"Title is private\" data-url=\"https://github.com/cryptonetlab/roadmap/issues/19\" data-hovercard-type=\"issue\" data-hovercard-url=\"/cryptonetlab/roadmap/issues/19/hovercard\" href=\"https://github.com/cryptonetlab/roadmap/issues/19\">cryptonetlab/roadmap#19</a></li>\n</ul>\n<p dir=\"auto\">eta: 2023Q2</p>\n<p dir=\"auto\">View in <a href=\"https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple\" rel=\"nofollow\">https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple</a></p>'
 const example_body_text = 'children:\n\nprotocol/bedrock#5\nprotocol/bedrock#11\nfilecoin-project/ref-fvm#1144\nfilecoin-project/ref-fvm#1143\nprotocol/netops#34\nprotocol/netops#47\ndrand/roadmap#8\ndrand/roadmap#12\nprotocol/ConsensusLab#180\nprotocol/ConsensusLab#185\nprotocol/ConsensusLab#186\nfilecoin-station/roadmap#3\nfilecoin-station/roadmap#10\nfilecoin-saturn/roadmap#1\nfilecoin-station/roadmap#4\nfilecoin-saturn/roadmap#2\ncryptonetlab/roadmap#19\n\neta: 2023Q2\nView in https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple'
 
+const expectedResult = [
+  {
+    group: 'children:',
+    html_url: 'https://github.com/protocol/bedrock/issues/5'
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/bedrock/issues/11",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1144",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1143",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/netops/issues/34",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/netops/issues/47",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/drand/roadmap/issues/8",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/drand/roadmap/issues/12",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/ConsensusLab/issues/180",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/ConsensusLab/issues/185",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/protocol/ConsensusLab/issues/186",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-station/roadmap/issues/3",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-station/roadmap/issues/10",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-saturn/roadmap/issues/1",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-station/roadmap/issues/4",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/filecoin-saturn/roadmap/issues/2",
+  },
+  {
+    "group": "children:",
+    "html_url": "https://github.com/cryptonetlab/roadmap/issues/19",
+  },
+]
+
 describe('parser', function() {
   describe('getChildren', function() {
     it('Can parse children from body_html', function() {
       const children = getChildren(example_body_html);
       expect(Array.isArray(children)).toBe(true);
       expect(children).toHaveLength(17);
-      expect(children).toStrictEqual([
-        {
-          group: 'children:',
-          html_url: 'https://github.com/protocol/bedrock/issues/5'
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/bedrock/issues/11",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1144",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1143",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/netops/issues/34",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/netops/issues/47",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/drand/roadmap/issues/8",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/drand/roadmap/issues/12",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/ConsensusLab/issues/180",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/ConsensusLab/issues/185",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/protocol/ConsensusLab/issues/186",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-station/roadmap/issues/3",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-station/roadmap/issues/10",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-saturn/roadmap/issues/1",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-station/roadmap/issues/4",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/filecoin-saturn/roadmap/issues/2",
-        },
-        {
-          "group": "children:",
-          "html_url": "https://github.com/cryptonetlab/roadmap/issues/19",
-        },
-      ])
+      expect(children).toStrictEqual(expectedResult)
+    })
+    it('Can parse children from body_text', function() {
+      const children = getChildren(example_body_text);
+      expect(Array.isArray(children)).toBe(true);
+      expect(children).toHaveLength(17);
+      expect(children).toStrictEqual(expectedResult)
     })
   })
 })

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,10 +1,21 @@
-import { getChildren, getChildrenNew } from '../../lib/parser';
+import { getChildren } from '../../lib/parser';
 
 /**
  * Test data obtained from calling getIssue() on github.com/protocol/engres/issues/5 on 2023-02-10 @ 5pm PST
  */
 const example_body_html = '<p dir=\"auto\">children:</p>\n<ul dir=\"auto\">\n<li><a aria-label=\"Issue #5\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468803547\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/5\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/5/hovercard\" href=\"https://github.com/protocol/bedrock/issues/5\">protocol/bedrock#5</a></li>\n<li><a aria-label=\"Issue #11\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1468828351\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/bedrock/issues/11\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/bedrock/issues/11/hovercard\" href=\"https://github.com/protocol/bedrock/issues/11\">protocol/bedrock#11</a></li>\n<li><a aria-label=\"Issue #1144\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462056698\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1144\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1144/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1144\">filecoin-project/ref-fvm#1144</a></li>\n<li><a aria-label=\"Issue #1143\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1462053266\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-project/ref-fvm/issues/1143\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-project/ref-fvm/issues/1143/hovercard\" href=\"https://github.com/filecoin-project/ref-fvm/issues/1143\">filecoin-project/ref-fvm#1143</a></li>\n<li><a aria-label=\"Issue #34\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470149244\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/34\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/34/hovercard\" href=\"https://github.com/protocol/netops/issues/34\">protocol/netops#34</a></li>\n<li><a aria-label=\"Issue #47\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1470248081\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/netops/issues/47\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/netops/issues/47/hovercard\" href=\"https://github.com/protocol/netops/issues/47\">protocol/netops#47</a></li>\n<li><a aria-label=\"Issue #8\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464684250\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/8\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/8/hovercard\" href=\"https://github.com/drand/roadmap/issues/8\">drand/roadmap#8</a></li>\n<li><a aria-label=\"Issue #12\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464687876\" data-permission-text=\"Title is private\" data-url=\"https://github.com/drand/roadmap/issues/12\" data-hovercard-type=\"issue\" data-hovercard-url=\"/drand/roadmap/issues/12/hovercard\" href=\"https://github.com/drand/roadmap/issues/12\">drand/roadmap#12</a></li>\n<li><a aria-label=\"Issue #180\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394534093\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/180\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/180/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/180\">protocol/ConsensusLab#180</a></li>\n<li><a aria-label=\"Issue #185\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394589312\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/185\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/185/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/185\">protocol/ConsensusLab#185</a></li>\n<li><a aria-label=\"Issue #186\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1394590754\" data-permission-text=\"Title is private\" data-url=\"https://github.com/protocol/ConsensusLab/issues/186\" data-hovercard-type=\"issue\" data-hovercard-url=\"/protocol/ConsensusLab/issues/186/hovercard\" href=\"https://github.com/protocol/ConsensusLab/issues/186\">protocol/ConsensusLab#186</a></li>\n<li><a aria-label=\"Issue #3\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461226183\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/3\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/3/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/3\">filecoin-station/roadmap#3</a></li>\n<li><a aria-label=\"Issue #10\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1575972127\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/10\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/10/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/10\">filecoin-station/roadmap#10</a></li>\n<li><a aria-label=\"Issue #1\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467798001\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/1\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/1/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/1\">filecoin-saturn/roadmap#1</a></li>\n<li><a aria-label=\"Issue #4\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1461231696\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-station/roadmap/issues/4\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-station/roadmap/issues/4/hovercard\" href=\"https://github.com/filecoin-station/roadmap/issues/4\">filecoin-station/roadmap#4</a></li>\n<li><a aria-label=\"Issue #2\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1467801960\" data-permission-text=\"Title is private\" data-url=\"https://github.com/filecoin-saturn/roadmap/issues/2\" data-hovercard-type=\"issue\" data-hovercard-url=\"/filecoin-saturn/roadmap/issues/2/hovercard\" href=\"https://github.com/filecoin-saturn/roadmap/issues/2\">filecoin-saturn/roadmap#2</a></li>\n<li><a aria-label=\"Issue #19\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"1464616958\" data-permission-text=\"Title is private\" data-url=\"https://github.com/cryptonetlab/roadmap/issues/19\" data-hovercard-type=\"issue\" data-hovercard-url=\"/cryptonetlab/roadmap/issues/19/hovercard\" href=\"https://github.com/cryptonetlab/roadmap/issues/19\">cryptonetlab/roadmap#19</a></li>\n</ul>\n<p dir=\"auto\">eta: 2023Q2</p>\n<p dir=\"auto\">View in <a href=\"https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple\" rel=\"nofollow\">https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple</a></p>'
 const example_body_text = 'children:\n\nprotocol/bedrock#5\nprotocol/bedrock#11\nfilecoin-project/ref-fvm#1144\nfilecoin-project/ref-fvm#1143\nprotocol/netops#34\nprotocol/netops#47\ndrand/roadmap#8\ndrand/roadmap#12\nprotocol/ConsensusLab#180\nprotocol/ConsensusLab#185\nprotocol/ConsensusLab#186\nfilecoin-station/roadmap#3\nfilecoin-station/roadmap#10\nfilecoin-saturn/roadmap#1\nfilecoin-station/roadmap#4\nfilecoin-saturn/roadmap#2\ncryptonetlab/roadmap#19\n\neta: 2023Q2\nView in https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple'
+const example_body = 'children: \r\n- https://github.com/protocol/bedrock/issues/5\r\n- https://github.com/protocol/bedrock/issues/11\r\n- https://github.com/filecoin-project/ref-fvm/issues/1144\r\n- https://github.com/filecoin-project/ref-fvm/issues/1143\r\n- https://github.com/protocol/netops/issues/34\r\n- https://github.com/protocol/netops/issues/47\r\n- https://github.com/drand/roadmap/issues/8\r\n- https://github.com/drand/roadmap/issues/12\r\n- https://github.com/protocol/ConsensusLab/issues/180\r\n- https://github.com/protocol/ConsensusLab/issues/185\r\n- https://github.com/protocol/ConsensusLab/issues/186\r\n- https://github.com/filecoin-station/roadmap/issues/3\r\n- https://github.com/filecoin-station/roadmap/issues/10\r\n- https://github.com/filecoin-saturn/roadmap/issues/1\r\n- https://github.com/filecoin-station/roadmap/issues/4\r\n- https://github.com/filecoin-saturn/roadmap/issues/2\r\n- https://github.com/cryptonetlab/roadmap/issues/19\r\n\r\neta: 2023Q2\r\n\r\nView in https://www.starmaps.app/roadmap/github.com/protocol/engres/issues/5#simple\r\n'
+
+/**
+ * Test data obtained from calling getIssue() on github.com/ipfs/ipfs-gui/issues/106 on 2023-02-10 @ 5:52pm PST
+ */
+const example_tasklist_body = 'eta: 2023Q4\r\n\r\nchildren:\r\n- [ ] #121\r\n- [ ] #122\r\n- [ ] #123\r\n- [ ] #124\r\n\r\n```[tasklist]\r\n### Tasks\r\n- [ ] #121\r\n- [ ] #122\r\n- [ ] #123\r\n- [ ] #124\r\n```\r\n'
+
+/**
+ * Test data manually removing "children:" from the above example_tasklist_body
+ */
+const example_tasklist_body_only = 'eta: 2023Q4\r\n\r\n```[tasklist]\r\n### Tasks\r\n- [ ] #121\r\n- [ ] #122\r\n- [ ] #123\r\n- [ ] #124\r\n```\r\n'
 
 const expectedResult = [
   {
@@ -12,84 +23,114 @@ const expectedResult = [
     html_url: 'https://github.com/protocol/bedrock/issues/5'
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/bedrock/issues/11",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/bedrock/issues/11',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1144",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-project/ref-fvm/issues/1144',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-project/ref-fvm/issues/1143",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-project/ref-fvm/issues/1143',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/netops/issues/34",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/netops/issues/34',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/netops/issues/47",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/netops/issues/47',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/drand/roadmap/issues/8",
+    group: 'children:',
+    html_url: 'https://github.com/drand/roadmap/issues/8',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/drand/roadmap/issues/12",
+    group: 'children:',
+    html_url: 'https://github.com/drand/roadmap/issues/12',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/ConsensusLab/issues/180",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/ConsensusLab/issues/180',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/ConsensusLab/issues/185",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/ConsensusLab/issues/185',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/protocol/ConsensusLab/issues/186",
+    group: 'children:',
+    html_url: 'https://github.com/protocol/ConsensusLab/issues/186',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-station/roadmap/issues/3",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-station/roadmap/issues/3',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-station/roadmap/issues/10",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-station/roadmap/issues/10',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-saturn/roadmap/issues/1",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-saturn/roadmap/issues/1',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-station/roadmap/issues/4",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-station/roadmap/issues/4',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/filecoin-saturn/roadmap/issues/2",
+    group: 'children:',
+    html_url: 'https://github.com/filecoin-saturn/roadmap/issues/2',
   },
   {
-    "group": "children:",
-    "html_url": "https://github.com/cryptonetlab/roadmap/issues/19",
+    group: 'children:',
+    html_url: 'https://github.com/cryptonetlab/roadmap/issues/19',
   },
 ]
 
 describe('parser', function() {
   describe('getChildren', function() {
-    it('Can parse children from body_html', function() {
-      const children = getChildren(example_body_html);
+    it('Can parse children from issue.body_html', function() {
+      const children = getChildren({ body_html: example_body_html, body: '', html_url: '' });
       expect(Array.isArray(children)).toBe(true);
       expect(children).toHaveLength(17);
       expect(children).toStrictEqual(expectedResult)
     })
-    it('Can parse children from body_text', function() {
-      const children = getChildren(example_body_text);
+    it('Can parse children from issue.body_text', function() {
+      const children = getChildren({ body_html: '', body: example_body_text, html_url: '' });
       expect(Array.isArray(children)).toBe(true);
       expect(children).toHaveLength(17);
       expect(children).toStrictEqual(expectedResult)
+    })
+    it('Can parse children from issue.body', function() {
+      const children = getChildren({ body_html: '', body: example_body, html_url: '' });
+      expect(Array.isArray(children)).toBe(true);
+      expect(children).toHaveLength(17);
+      expect(children).toStrictEqual(expectedResult)
+    })
+
+    it('Can parse tasklist children from body that also has children:', function() {
+      const children = getChildren({ body_html: '', body: example_tasklist_body, html_url: 'https://github.com/ipfs/ipfs-gui/issues/106' });
+      expect(Array.isArray(children)).toBe(true);
+      expect(children).toHaveLength(4);
+      expect(children).toStrictEqual([
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/121' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/122' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/123' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/124' }
+      ])
+    })
+
+    it('Can parse tasklist children from body', function() {
+      const children = getChildren({ body_html: '', body: example_tasklist_body_only, html_url: 'https://github.com/ipfs/ipfs-gui/issues/106' });
+      expect(Array.isArray(children)).toBe(true);
+      expect(children).toHaveLength(4);
+      expect(children).toStrictEqual([
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/121' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/122' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/123' },
+        { group: 'tasklist', html_url: 'https://github.com/ipfs/ipfs-gui/issues/124' }
+      ])
     })
   })
 })


### PR DESCRIPTION
Example issue using tasklists: https://github.com/ipfs/ipfs-gui/issues/106

Note that it's milestone children are *not* using tasklists, and their children are still recognized properly. 

demo: https://starmaps-git-313-add-support-for-parsing-tas-282722-ipfs-ignite.vercel.app/roadmap/github.com/ipfs/ipfs-gui/issues/106#simple