### PR TITLE
fix(ci): 🐛 broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         yarn test:ci
 
     - name: Publish Code Coverage
+      if: github.repository === 'pln-planning-tools/Starmap'
       uses: paambaati/codeclimate-action@v3.2.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         yarn test:ci
 
     - name: Publish Code Coverage
-      if: github.repository === 'pln-planning-tools/Starmap'
+      if: github.repository == 'pln-planning-tools/Starmap'
       uses: paambaati/codeclimate-action@v3.2.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}


### PR DESCRIPTION
had a bad `equal` comparison. It's been broken.