### PR TITLE
fix: decode parentJson before parsing it

### DIFF
--- a/pages/api/pendingChild.ts
+++ b/pages/api/pendingChild.ts
@@ -16,7 +16,8 @@ export default async function handler(
     return
   }
   const { owner, repo, issue_number, parentJson } = req.query;
-  const parent = JSON.parse(parentJson as string);
+  const parentJsonDecoded = decodeURIComponent(parentJson as string);
+  const parent = JSON.parse(parentJsonDecoded);
   const errorManager = new ErrorManager();
 
   if (process.env.IS_LOCAL === 'true') {

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -105,7 +105,10 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
 
       } catch (err) {
         if (!(err as Error).toString().includes('AbortError')) {
-          roadmapLoadErrorState.set({ code: `Error fetching ${roadmapApiUrl}`, message: `Error fetching ${roadmapApiUrl}: ${(err as Error).toString()}` })
+          roadmapLoadErrorState.set({
+            code: `Error fetching api/roadmap for ${owner}/${repo}#${issue_number}`,
+            message: `Error fetching api/roadmap for ${owner}/${repo}#${issue_number}: ${(err as Error).toString()}`
+          })
         }
       }
       setIsRootIssueLoading(false);
@@ -167,7 +170,10 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
         }
       } catch (err) {
         if (!(err as Error).toString().includes('AbortError')) {
-          roadmapLoadErrorState.set({ code: `Error fetching ${pendingChildApiUrl}`, message: `Error fetching ${pendingChildApiUrl}: ${(err as Error).toString()}` })
+          roadmapLoadErrorState.set({
+            code: `Error fetching api/pendingChild for ${owner}/${repo}#${issue_number}`,
+            message: `Error fetching api/pendingChild for ${owner}/${repo}#${issue_number}: ${(err as Error).toString()}`
+          })
         }
       }
       pendingChildrenState[0].set(none);


### PR DESCRIPTION
fix #350

You can see the success at https://starmaps-git-350-bug-fetcherrors-from-sw-sho-c305f4-ipfs-ignite.vercel.app/api/pendingChild?owner=drand&repo=roadmap&issue_number=12&parentJson=%7B%22labels%22%3A%5B%5D%2C%22completion_rate%22%3A0%2C%22due_date%22%3A%222023-06-30%22%2C%22html_url%22%3A%22https%3A%2F%2Fgithub.com%2Fprotocol%2Fengres%2Fissues%2F8%22%2C%22group%22%3A%22Children%3A%22%2C%22title%22%3A%22EngRes%20Theme%3A%20Critical%20System%20Stewardship%20%26%20Growth%22%2C%22state%22%3A%22open%22%2C%22node_id%22%3A%22I_kwDOIiXv285gZJEN%22%2C%22parent%22%3A%7B%22state%22%3A%22open%22%2C%22group%22%3A%22root%22%2C%22title%22%3A%22EngRes%20Theme-Based%202023%20Roadmap%22%2C%22html_url%22%3A%22https%3A%2F%2Fgithub.com%2Fprotocol%2Fengres%2Fissues%2F9%22%2C%22labels%22%3A%5B%5D%2C%22node_id%22%3A%22I_kwDOIiXv285gZJpY%22%2C%22completion_rate%22%3A0%2C%22due_date%22%3A%222023-06-30%22%2C%22description%22%3A%22%22%7D%2C%22children%22%3A%5B%5D%2C%22description%22%3A%22%22%7D

And failures at https://starmap.site/api/pendingChild?owner=drand&repo=roadmap&issue_number=12&parentJson=%7B%22labels%22%3A%5B%5D%2C%22completion_rate%22%3A0%2C%22due_date%22%3A%222023-06-30%22%2C%22html_url%22%3A%22https%3A%2F%2Fgithub.com%2Fprotocol%2Fengres%2Fissues%2F8%22%2C%22group%22%3A%22Children%3A%22%2C%22title%22%3A%22EngRes%20Theme%3A%20Critical%20System%20Stewardship%20%26%20Growth%22%2C%22state%22%3A%22open%22%2C%22node_id%22%3A%22I_kwDOIiXv285gZJEN%22%2C%22parent%22%3A%7B%22state%22%3A%22open%22%2C%22group%22%3A%22root%22%2C%22title%22%3A%22EngRes%20Theme-Based%202023%20Roadmap%22%2C%22html_url%22%3A%22https%3A%2F%2Fgithub.com%2Fprotocol%2Fengres%2Fissues%2F9%22%2C%22labels%22%3A%5B%5D%2C%22node_id%22%3A%22I_kwDOIiXv285gZJpY%22%2C%22completion_rate%22%3A0%2C%22due_date%22%3A%222023-06-30%22%2C%22description%22%3A%22%22%7D%2C%22children%22%3A%5B%5D%2C%22description%22%3A%22%22%7D